### PR TITLE
feat: Add default Guzzle configuration for API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ use BushlanovDev\MaxMessengerBot\Api;
 
 $api = new Api('YOUR_BOT_API_TOKEN');
 
+// Использовать свой сертификат
+$api = new Api('YOUR_BOT_API_TOKEN', guzzleConfig: ['verify' => '/path/to/cert.crt']);
+
+// Настроить прокси и таймауты
+$api = new Api('YOUR_BOT_API_TOKEN', guzzleConfig: [
+    'timeout' => 60,
+    'proxy' => 'tcp://proxy:8080'
+]);
+
 // Загрузка файла
 $fileAttachmentRequest = $api->uploadAttachment(
     type: UploadType::File,

--- a/src/Api.php
+++ b/src/Api.php
@@ -52,6 +52,14 @@ class Api
 
     public const string API_VERSION = '1.2.5';
 
+    private const array DEFAULT_GUZZLE_CONFIG = [
+        'timeout' => 10,
+        'connect_timeout' => 5,
+        'read_timeout' => 10,
+        'headers' => ['User-Agent' => 'max-bot-api-client-php/' . self::LIBRARY_VERSION . ' PHP/' . PHP_VERSION],
+        'verify' => false
+    ];
+    
     private const string API_BASE_URL = 'https://platform-api2.max.ru';
 
     private const string METHOD_GET = 'GET';
@@ -115,12 +123,10 @@ class Api
                 );
             }
 
-            $guzzle = new \GuzzleHttp\Client([
-                'timeout' => 10,
-                'connect_timeout' => 5,
-                'read_timeout' => 10,
-                'headers' => ['User-Agent' => 'max-bot-api-client-php/' . self::LIBRARY_VERSION . ' PHP/' . PHP_VERSION],
-            ]);
+            $finalGuzzleConfig = $guzzleConfig !== null
+                ? array_merge(self::DEFAULT_GUZZLE_CONFIG, $guzzleConfig)
+                : self::DEFAULT_GUZZLE_CONFIG;
+            $guzzle = new \GuzzleHttp\Client($finalGuzzleConfig);
             $httpFactory = new \GuzzleHttp\Psr7\HttpFactory();
             $client = new Client(
                 $accessToken,

--- a/src/Api.php
+++ b/src/Api.php
@@ -100,6 +100,7 @@ class Api
      * @param ClientApiInterface|null $client Http api client.
      * @param ModelFactory|null $modelFactory The model factory.
      * @param LoggerInterface|null $logger PSR LoggerInterface.
+     * @param array|null $guzzleConfig Additional configuration for the default Guzzle HTTP client.
      *
      * @throws InvalidArgumentException
      */
@@ -108,6 +109,7 @@ class Api
         ?ClientApiInterface $client = null,
         ?ModelFactory $modelFactory = null,
         ?LoggerInterface $logger = null,
+        ?array $guzzleConfig = null,
     ) {
         if (empty($accessToken) && $client === null) {
             throw new InvalidArgumentException('You must provide either an access token or a client.');

--- a/src/Api.php
+++ b/src/Api.php
@@ -100,7 +100,7 @@ class Api
      * @param ClientApiInterface|null $client Http api client.
      * @param ModelFactory|null $modelFactory The model factory.
      * @param LoggerInterface|null $logger PSR LoggerInterface.
-     * @param array|null $guzzleConfig Additional configuration for the default Guzzle HTTP client.
+     * @param array<string, mixed>|null $guzzleConfig Additional configuration for the default Guzzle HTTP client.
      *
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
По умолчанию SSL игнорируется, чтобы не вызывало ошибку.
Теперь вы можете передать  свой SSL, а так же указать другие параметры если вы не используете свой client
```php
// Включить проверку SSL-сертификатов
$api = new Api(
    'YOUR_BOT_API_TOKEN',
    guzzleConfig: ['verify' => true]
);

// Использовать свой сертификат
$api = new Api(
    'YOUR_BOT_API_TOKEN',
    guzzleConfig: ['verify' => '/path/to/certificate.crt']
);

// Настроить таймауты и прокси
$api = new Api(
    'YOUR_BOT_API_TOKEN',
    guzzleConfig: [
        'timeout' => 60,
        'proxy' => 'tcp://proxy.example.com:8080'
    ]
);
```