### PR TITLE
Add new chat admin permission constants

### DIFF
--- a/src/Enums/ChatAdminPermission.php
+++ b/src/Enums/ChatAdminPermission.php
@@ -20,4 +20,7 @@ enum ChatAdminPermission: string
     case PostEditDeleteMessage = 'post_edit_delete_message';
     case EditMessage = 'edit_message';
     case DeleteMessage = 'delete_message';
+    case Delete = 'delete';
+    case Edit = 'edit';
+    case ViewStats = 'view_stats';
 }


### PR DESCRIPTION
похоже, появились новые пермишены, и getAdmins() падает, когда в ответе они появляются.
https://dev.max.ru/docs-api/objects/ChatMember
```
$ curl -X GET "https://platform-api2.max.ru/chats/-76771840195654/members/admins" \
 -H "Authorization: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
```
`
{"members":[{"last_access_time":1784659950640,"is_owner":true,"is_admin":true,"join_time":1783685217643,"permissions":["write","edit_link","add_admins","change_chat_info","pin_message","add_remove_members","can_call","read_all_messages","delete","edit","view_stats"], ...`
